### PR TITLE
fix: upgrade @tencent-sdk/capi to ^2.0.0 to fix proxy issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@serverless/utils-china",
   "description": "Tencent Cloud Tools For Serverless Framewoek",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "publishConfig": {
     "access": "public"
   },
@@ -36,7 +36,7 @@
     ]
   },
   "dependencies": {
-    "@tencent-sdk/capi": "^1.1.8",
+    "@tencent-sdk/capi": "^2.0.0",
     "dijkstrajs": "^1.0.1",
     "dot-qs": "0.2.0",
     "duplexify": "^4.1.1",

--- a/sdk/account/isRealNameVerified.js
+++ b/sdk/account/isRealNameVerified.js
@@ -6,16 +6,16 @@ async function isRealNameVerified({ secretId, secretKey, token }) {
   const client = new Capi({
     debug: false,
     host: 'account.tencentcloudapi.com',
-    Version: '2018-12-25',
-    Region: 'ap-guangzhou',
-    SecretId: secretId,
-    SecretKey: secretKey,
-    Token: token,
-    ServiceType: 'account',
+    version: '2018-12-25',
+    region: 'ap-guangzhou',
+    secretId,
+    secretKey,
+    token,
+    serviceType: 'account',
   });
   try {
     const { Response } = await client.request({
-      Action: 'GetAuthStatus',
+      action: 'GetAuthStatus',
     });
     return Number(Response.Status) === 3;
   } catch (e) {

--- a/sdk/debug/lib/apiRequest.js
+++ b/sdk/debug/lib/apiRequest.js
@@ -18,15 +18,15 @@ const ApiRequest = function (auth, func, Region, debugOptions) {
   }
 
   this.client = new Capi({
-    Region,
-    SecretId,
-    SecretKey,
-    Token,
-    ServiceType: 'scf',
+    region: Region,
+    secretId: SecretId,
+    secretKey: SecretKey,
+    token: Token,
+    serviceType: 'scf',
     baseHost: 'tencentcloudapi.com',
   });
   this.commonParams = {
-    Version: '2018-04-16',
+    version: '2018-04-16',
     ...body,
   };
   this.debugOptions = debugOptions;
@@ -35,7 +35,7 @@ const ApiRequest = function (auth, func, Region, debugOptions) {
 ApiRequest.prototype.request = async function (action, params) {
   const result = await this.client.request(
     {
-      Action: action,
+      action,
       ...this.commonParams,
       ...params,
     },

--- a/sdk/serverless/index.js
+++ b/sdk/serverless/index.js
@@ -20,13 +20,13 @@ class Serverless {
     this._slsClient = new Capi({
       debug: false,
       host: 'sls.tencentcloudapi.com',
-      Version: '2020-02-05',
-      Region: this.region,
-      SecretId: secretId,
-      SecretKey: secretKey,
-      Token: options.token,
-      ServiceType: 'sls',
-      RequestClient: options.sdkAgent || 'ServerlessFramework',
+      version: '2020-02-05',
+      region: this.region,
+      secretId,
+      secretKey,
+      token: options.token,
+      serviceType: 'sls',
+      requestClient: options.sdkAgent || 'ServerlessFramework',
     });
   }
 
@@ -129,7 +129,7 @@ class Serverless {
 
   async _call(api, params) {
     const { Response } = await this._slsClient.request({
-      Action: api,
+      action: api,
       ...params,
     });
     if (Response.Error) {


### PR DESCRIPTION
close: https://app.asana.com/0/1200011502754281/1201740900896483/f
---
当前使用的 `@tencent-sdk/capi` 包中，使用的`request`依赖会在配置了命令行代理下情况下报错，详情见ticket。 capi在`>2.0.0` 之后使用 `got` 替代了 `request`, 可以修复此问题: https://github.com/serverless-plus/tencent-sdk/blob/master/packages/capi/package.json#L26

1. 升级 `@tencent-sdk/capi` 到 `^2.0.0`
2. 兼容capi中的字段请求，首字母改为了小写: https://github.com/serverless-plus/tencent-sdk/blob/master/packages/capi/src/index.ts#L9-L28