### PR TITLE
Caret winston

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "protobufjs": "^6.9.0",
     "qrcode-terminal": "^0.12.0",
     "socket.io-client": "^2.3.0",
-    "winston": "3.2.1"
+    "winston": "^3.2.1"
   },
   "devDependencies": {
     "@serverless/eslint-config": "^3.0.0",


### PR DESCRIPTION
You have pinned Winston version `3.2.1` but we depend on `3.3.0` which is causing Winston to not resolve flat.

Caret Winston so newer minor updates can be pulled in. This shouldn't cause any issues since its not a major version bump, unless something accidental happened with the Winston maintainers.